### PR TITLE
crawling 리팩토링 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ beautifulsoup4==4.12.2
 kiwipiepy==0.16.0
 google-cloud-bigquery==3.13.0
 PyYAML==6.0.1
+selenium==4.17.2

--- a/script/crawling.py
+++ b/script/crawling.py
@@ -714,7 +714,7 @@ class CrawlingWanted(Crawling):
 
             content_dict = {}
             for position_url in job_info["position_list"]:
-                driver.get(f"self.endpoint{position_url}")
+                driver.get(f"{self.endpoint}{position_url}")
                 time.sleep(0.1)
                 content_dict[position_url] = driver.page_source
 

--- a/script/crawling.py
+++ b/script/crawling.py
@@ -19,14 +19,18 @@ class Crawling:
             'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36'
         }
         self.driver = webdriver.Safari if sys.platform.lower() == "darwin" else webdriver.Chrome
+        if not os.path.exists(data_path):
+            os.mkdir(data_path)
         self.data_path = data_path
+        self.site_name = site_name
+
         self.info_key2name = {
             "경력": "career",
             "학력": "academic_background",
             "마감일": "deadline",
             "근무지역": "location"
         }
-        self.site_name = site_name
+
         self.filenames = {
             "url_list": os.path.join(self.data_path, f"{self.site_name}.url_list.json"),
             "content_info": os.path.join(self.data_path, f"{self.site_name}.content_info.json"),
@@ -630,7 +634,6 @@ class CrawlingWanted(Crawling):
             with open(filename) as f:
                 job_dict = json.load(f)
 
-        job_dict = {}
         for job_category in self.job_category_id2name:
             if job_category in job_dict:
                 continue

--- a/script/crawling.py
+++ b/script/crawling.py
@@ -534,13 +534,14 @@ class CrawlingJobPlanet(Crawling):
             with open(self.filenames["content_info"]) as f:
                 postprocess_dict = json.load(f)
 
+        job_category_name2id = {job_name: _id for _id, job_name in enumerate(position_content_dict.keys())}
+
         for job_name, info_dict in position_content_dict.items():
             for url, page_source in info_dict.items():
                 soup = BeautifulSoup(page_source, "html.parser")
                 dd_list = soup.select("dd.recruitment-summary__dd")
                 dt_list = soup.select("dt.recruitment-summary__dt")
 
-                deadline = None
                 tech_list = []
                 extra_info = {}
                 for dt_num in range(len(dt_list)):
@@ -555,11 +556,10 @@ class CrawlingJobPlanet(Crawling):
                         if "상시" in value or deadline_pat is None:
                             deadline = ""
                         else:
-                            deadline = deadline_pat.group().strip()
+                            deadline = deadline_pat.group().strip().replace(".", "-")
                         extra_info[self.info_key2name["마감일"]] = deadline
 
                     elif key in self.info_key2name.keys():
-
                         extra_info[self.info_key2name[key]] = value
 
                 try:
@@ -575,8 +575,9 @@ class CrawlingJobPlanet(Crawling):
                     company_id, company_name = "", ""
 
                 result = {
-                    "url": f"{self.endpoint}{url}",
+                    "url": url,
                     "job_name": job_name,
+                    "job_category": job_category_name2id[job_name],
                     "title": title,
                     "company_name": company_name,
                     "company_id": company_id,

--- a/script/crawling.py
+++ b/script/crawling.py
@@ -607,6 +607,7 @@ class CrawlingJobPlanet(Crawling):
         result_dict = self.postprocess(position_content_dict)
         return result_dict
 
+
 class CrawlingWanted(Crawling):
     """
     Crawling of "https://www.wanted.co.kr"
@@ -722,7 +723,7 @@ class CrawlingWanted(Crawling):
             content_dict = {}
             for position_url in job_info["position_list"]:
                 driver.get(f"{self.endpoint}{position_url}")
-                time.sleep(0.1)
+                time.sleep(1)
                 content_dict[position_url] = driver.page_source
 
             position_content_dict[job_category] = content_dict
@@ -754,14 +755,17 @@ class CrawlingWanted(Crawling):
                 result = {
                     "url": f"{self.endpoint}{url}",
                     "job_category": job_category,
-                    "job_name": self.job_category_id2name[job_category]
+                    "job_name": self.job_category_id2name[int(job_category)]
                 }
 
                 soup = BeautifulSoup(content, 'html')
 
                 job_header = soup.find("section", class_="JobHeader_className__HttDA")
 
-                result['title'] = job_header.find("h2").text
+                try:
+                    result['title'] = job_header.find("h2").text
+                except AttributeError:
+                    continue
 
                 _company_info = job_header.find("span", class_="JobHeader_companyNameText__uuJyu")
                 result['company_name'] = _company_info.text

--- a/script/crawling.py
+++ b/script/crawling.py
@@ -173,7 +173,14 @@ class CrawlingJumpit(Crawling):
 
         return position_content_dict
 
-    def postprocess(self, position_content_dict):
+    def postprocess(self, position_content_dict=None):
+        if position_content_dict is None:
+            if os.path.exists(self.filenames["content_info"]):
+                with open(self.filenames["content_info"]) as f:
+                    position_content_dict = json.load(f)
+            else:
+                position_content_dict = self.get_recruit_content_info()
+
         file = open(self.filenames["result"], "w")
 
         postprocess_dict = {}
@@ -727,7 +734,14 @@ class CrawlingWanted(Crawling):
 
         return position_content_dict
 
-    def postprocess(self, position_content_dict):
+    def postprocess(self, position_content_dict=None):
+        if position_content_dict is None:
+            if os.path.exists(self.filenames["content_info"]):
+                with open(self.filenames["content_info"]) as f:
+                    position_content_dict = json.load(f)
+            else:
+                position_content_dict = self.get_recruit_content_info()
+
         file = open(self.filenames["result"], "w")
 
         postprocess_dict = {}


### PR DESCRIPTION
Resolve #35 

- 크롤링 과정 3단계로 구성
    1. get_url_list: 채용공고 url 목록 불러오기 (직무 카테고리별로 분류해서 저장)
    2. get_recruit_content_info: 채용공고 url별 page source 불러오기
    3. postprocess: 채용공고 url page source별 정보 추출
- 각 단계별로 실행 가능하도록 구현 (-m 옵션 통해 실행할 단계 입력 가능)
: ex) `python3 script/crawling.py -s jobplanet -d ./data -m get_url_list`
- 각 단계별 결과물 중간에 저장되도록 구현 (중단되더라도 이어서 진행될 수 있도록)
    - get_url_list: {사이트명}.url_list.json
    - get_recruit_content_info: {사이트명}.content_info.json
    - postprocess: {사이트명}.result.jsonl
- driver 각 함수별로 인스턴스 생성되도록 변경
- 기타 크롤링 오류 수정 (jobplanet / wanted)